### PR TITLE
Only wrap Promise.prototype.on if it exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,12 +12,14 @@ module.exports = function patchMPromise(ns, _mongoose) {
     throw new TypeError("must include namespace to patch Mongoose against");
   }
 
-  shimmer.wrap(mongoose.Mongoose.prototype.Promise.prototype, 'on', function (original) {
-    return function(event, callback) {
-      callback = ns.bind(callback);
-      return original.call(this, event, callback);
-    };
-  });
+  if (mongoose.Mongoose.prototype.Promise.prototype.on) {
+    shimmer.wrap(mongoose.Mongoose.prototype.Promise.prototype, 'on', function (original) {
+      return function(event, callback) {
+        callback = ns.bind(callback);
+        return original.call(this, event, callback);
+      };
+    });
+  }
 
   shimmer.wrap(mongoose.Mongoose.prototype.Query.prototype, 'exec', function (original) {
     return function(op, callback) {


### PR DESCRIPTION
First of all... thank you for writing this shim! It's helped us use CLS and has been a developer win for us. After using this shim however we started seeing a lot of `no original function on to wrap` messages in our logs. After some tracking and reading from [this StackOverflow](https://stackoverflow.com/a/51862948) (and the linked Mongoose documentation), it looks like native Promises are used in Mongoose version 5 which don't have a `on` method. This wraps the shimmer.wrap call in a check to see if that function actually exists. 